### PR TITLE
[Feat/#11] 예외발생시 관리하는 Handler 구현

### DIFF
--- a/src/main/java/com/bootios/alone/global/error/ErrorCode.java
+++ b/src/main/java/com/bootios/alone/global/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.bootios.alone.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** {주체}_{이유} message 는 동사 명사형으로 마무리 */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // Global
+    INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
+    INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
+
+    // 예시
+    // User 도메인
+    EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/bootios/alone/global/error/ErrorCode.java
+++ b/src/main/java/com/bootios/alone/global/error/ErrorCode.java
@@ -7,16 +7,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    // Global
-    INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
-    INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
+  // Global
+  INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
+  INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
 
-    // 예시
-    // User 도메인
-    EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
-    ;
+  // 예시
+  // User 도메인
+  EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
+  ;
 
-    private final int status;
-    private final String code;
-    private final String message;
+  private final int status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/bootios/alone/global/error/ErrorResponse.java
+++ b/src/main/java/com/bootios/alone/global/error/ErrorResponse.java
@@ -1,0 +1,61 @@
+package com.bootios.alone.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+  private String businessCode;
+  private String errorMessage;
+  private List<FieldError> errors;
+
+  private ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
+    this.businessCode = code.getCode();
+    this.errorMessage = code.getMessage();
+    this.errors = fieldErrors;
+  }
+
+  private ErrorResponse(ErrorCode code) {
+    this.businessCode = code.getCode();
+    this.errorMessage = code.getMessage();
+    this.errors = new ArrayList<>();
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors =
+          bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(
+              error ->
+                  new FieldError(
+                      error.getField(),
+                      error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                      error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/bootios/alone/global/error/ErrorResponse.java
+++ b/src/main/java/com/bootios/alone/global/error/ErrorResponse.java
@@ -1,14 +1,13 @@
 package com.bootios.alone.global.error;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Builder
 @Getter

--- a/src/main/java/com/bootios/alone/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bootios/alone/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.bootios.alone.global.error;
 
+import static com.bootios.alone.global.error.ErrorCode.INPUT_INVALID_VALUE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import com.bootios.alone.global.error.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -7,9 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import static com.bootios.alone.global.error.ErrorCode.INPUT_INVALID_VALUE;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/com/bootios/alone/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bootios/alone/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.bootios.alone.global.error;
+
+import com.bootios.alone.global.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.bootios.alone.global.error.ErrorCode.INPUT_INVALID_VALUE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error(e.getMessage(), e);
+    ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler
+  protected ResponseEntity<ErrorResponse> handleRuntimeException(BusinessException e) {
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response =
+        ErrorResponse.builder()
+            .errorMessage(errorCode.getMessage())
+            .businessCode(errorCode.getCode())
+            .build();
+    log.warn(e.getMessage());
+    return ResponseEntity.status(errorCode.getStatus()).body(response);
+  }
+
+  @ExceptionHandler
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    final ErrorResponse response = ErrorResponse.of(INPUT_INVALID_VALUE, e.getBindingResult());
+    log.warn(e.getMessage());
+    return new ResponseEntity<>(response, BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/bootios/alone/global/error/exception/BusinessException.java
+++ b/src/main/java/com/bootios/alone/global/error/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.bootios.alone.global.error.exception;
+
+import com.bootios.alone.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/bootios/alone/global/result/ResultCode.java
+++ b/src/main/java/com/bootios/alone/global/result/ResultCode.java
@@ -1,0 +1,21 @@
+package com.bootios.alone.global.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** {행위}_{목적어}_{성공여부} message 는 동사 명사형으로 마무리 */
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+
+  // 도메인 별로 나눠서 관리(ex: User 도메인)
+  // user
+
+
+  // post
+
+ ;
+
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/bootios/alone/global/result/ResultCode.java
+++ b/src/main/java/com/bootios/alone/global/result/ResultCode.java
@@ -8,13 +8,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResultCode {
 
-  // 도메인 별로 나눠서 관리(ex: User 도메인)
-  // user
+// 도메인 별로 나눠서 관리(ex: User 도메인)
+// user
 
+// post
 
-  // post
-
- ;
+;
 
   private final String code;
   private final String message;

--- a/src/main/java/com/bootios/alone/global/result/ResultResponse.java
+++ b/src/main/java/com/bootios/alone/global/result/ResultResponse.java
@@ -1,0 +1,25 @@
+package com.bootios.alone.global.result;
+
+import lombok.Getter;
+
+@Getter
+public class ResultResponse {
+
+  private String code;
+  private String message;
+  private Object data;
+
+  public static ResultResponse of(ResultCode resultCode, Object data) {
+    return new ResultResponse(resultCode, data);
+  }
+
+  public static ResultResponse of(ResultCode resultCode) {
+    return new ResultResponse(resultCode, "");
+  }
+
+  public ResultResponse(ResultCode resultCode, Object data) {
+    this.code = resultCode.getCode();
+    this.message = resultCode.getMessage();
+    this.data = data;
+  }
+}

--- a/src/test/java/com/bootios/alone/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bootios/alone/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,111 @@
+package com.bootios.alone.error;
+
+import com.bootios.alone.global.error.GlobalExceptionHandler;
+import com.bootios.alone.global.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
+import static com.bootios.alone.global.error.ErrorCode.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ContextConfiguration(
+    classes = {GlobalExceptionHandlerTest.TestController.class, GlobalExceptionHandler.class})
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
+class GlobalExceptionHandlerTest {
+  private MockMvc mockMvc;
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp(WebApplicationContext webApplicationContext) {
+    mockMvc =
+        MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilters(new CharacterEncodingFilter("UTF-8", true))
+            .build();
+
+    objectMapper = new ObjectMapper();
+  }
+
+  @DisplayName("잘못된 input 예외 handler test")
+  @Test
+  void handleMethodArgumentNotValidException() throws Exception {
+    MockRequest mockRequest = new MockRequest(0);
+
+    mockMvc
+        .perform(
+            post("/exception")
+                .content(objectMapper.writeValueAsString(mockRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.businessCode").value(INPUT_INVALID_VALUE.getCode()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("business 예외 handler test")
+  void handleBusinessException() throws Exception {
+    mockMvc
+        .perform(get("/exception/1"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.businessCode").value(EXAMPLE_USER_ERROR.getCode()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("500 에러 handler test")
+  void handleException() throws Exception {
+    mockMvc
+        .perform(
+            post("/exception")
+                .content(objectMapper.writeValueAsString(new MockRequest(1)))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.businessCode").value(INTERNAL_SERVER_ERROR.getCode()))
+        .andDo(print());
+  }
+
+  private static class MockRequest {
+    @Positive private int ping;
+
+    public MockRequest() {}
+
+    public MockRequest(int ping) {
+      this.ping = ping;
+    }
+
+    public int getPing() {
+      return ping;
+    }
+  }
+
+  @RestController
+  @RequestMapping("/exception")
+  static class TestController {
+    @GetMapping("/{id}")
+    public String executeBusinessException(@PathVariable Long id) {
+      throw new BusinessException(EXAMPLE_USER_ERROR);
+    }
+
+    @PostMapping
+    public String executeException(@RequestBody @Valid MockRequest mockRequest) {
+      throw new RuntimeException();
+    }
+  }
+}

--- a/src/test/java/com/bootios/alone/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bootios/alone/error/GlobalExceptionHandlerTest.java
@@ -1,8 +1,17 @@
 package com.bootios.alone.error;
 
+import static com.bootios.alone.global.error.ErrorCode.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.bootios.alone.global.error.GlobalExceptionHandler;
 import com.bootios.alone.global.error.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,16 +23,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Positive;
-
-import static com.bootios.alone.global.error.ErrorCode.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ContextConfiguration(
     classes = {GlobalExceptionHandlerTest.TestController.class, GlobalExceptionHandler.class})


### PR DESCRIPTION
## 추가한 기능 설명
- 예외발생시 실행할 GlobalExceptionHandler 구현
- 예외발생시 반환할 ErrorResponse 구현
- 에러코드및 성공시 결과 값을 반환하는 Enum 클래스 구현
- RuntimeException을 상속받은 BusinessException 클래스 구현
- 예외 핸들러 테스트 코드 작성

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?